### PR TITLE
RMET-1538 Firebase Core - Improve the way we log an error when .zip not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The changes documented here do not include those from the original repository.
+
+## [Unreleased]
+
+### 2021-05-09
+- Improve error message when .zip is not found (https://outsystemsrd.atlassian.net/browse/RMET-1538)
+
+## 1.0.0

--- a/hooks/unzipAndCopyConfigurations.js
+++ b/hooks/unzipAndCopyConfigurations.js
@@ -29,8 +29,7 @@ module.exports = function(context) {
   var sourceFolderPath = utils.getSourceFolderPath(context, wwwPath);
   var googleServicesZipFile = utils.getZipFile(sourceFolderPath, constants.googleServices);
   if (!googleServicesZipFile) {
-    //utils.handleError("No zip file found containing google services configuration file", defer);
-    throw new Error("No configuration zip file found (google-services-zip).");
+    throw new Error("No configuration zip file found (google-services-zip). You can check how to configure this file at: https://success.outsystems.com/Documentation/11/Extensibility_and_Integration/Mobile_Plugins/Firebase_Plugins");
   }
 
   var zip = new AdmZip(googleServicesZipFile);

--- a/hooks/unzipAndCopyConfigurations.js
+++ b/hooks/unzipAndCopyConfigurations.js
@@ -29,7 +29,8 @@ module.exports = function(context) {
   var sourceFolderPath = utils.getSourceFolderPath(context, wwwPath);
   var googleServicesZipFile = utils.getZipFile(sourceFolderPath, constants.googleServices);
   if (!googleServicesZipFile) {
-    utils.handleError("No zip file found containing google services configuration file", defer);
+    //utils.handleError("No zip file found containing google services configuration file", defer);
+    throw new Error("No configuration zip file found (google-services-zip).");
   }
 
   var zip = new AdmZip(googleServicesZipFile);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR improves the way we log an error message when the .zip configuration file is not found. By throwing an error instead of simply doing `console.log`, the error will appear more clearly in the build logs.
- It also improves the error message we send.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1538

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS builds with this new way of sending an error to the logs.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
